### PR TITLE
Fix large response payload

### DIFF
--- a/lib/ip-to-asn.js
+++ b/lib/ip-to-asn.js
@@ -18,15 +18,21 @@ var IPToASN = function () {
 IPToASN.prototype.query = function (addresses, callback) {
   var that = this;
   var client = net.connect(this.serviceOptions);
+  var chunks = [];
   client.setEncoding('utf8');
 
   client.on('connect', function () {
+    chunks = [];
     var request = that._generateRequest(addresses);
     client.write(request);
   });
 
   client.on('data', function (response) {
-    var results = that._handleResponse(response, callback);
+    chunks.push(response);
+  });
+  
+  client.on('end', function() {
+    var results = that._handleResponse(chunks.join(''), callback);
     callback(null, results);
   });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ip-to-asn",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "./lib/ip-to-asn.js",
   "description": "client for Team Cymru's IP to ASN Service",
   "scripts": {


### PR DESCRIPTION
Currently if the response is too big, it's not getting parsed correctly.

Proposed change accumulates all chunks before attempting to parse.